### PR TITLE
Revert "fix(deps): update quay.io/thanos/thanos docker tag to v0.23.2"

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/helm-release.yaml
@@ -205,7 +205,7 @@ spec:
                 requests:
                   storage: 10Gi
         thanos:
-          image: quay.io/thanos/thanos:v0.23.2
+          image: quay.io/thanos/thanos:v0.23.1
           version: v0.22.0
           objectStorageConfig:
             name: thanos-objstore


### PR DESCRIPTION
Reverts onedr0p/home-ops#2539

Thanos image is not available yet.