### PR TITLE
Revert "feat(container): update ghcr.io/k8s-at-home/qbittorrent docker tag to v4.4.0"

### DIFF
--- a/cluster/apps/media/qbittorrent/helm-release.yaml
+++ b/cluster/apps/media/qbittorrent/helm-release.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: ghcr.io/k8s-at-home/qbittorrent
-      tag: v4.4.0
+      tag: v4.3.9
     env:
       TZ: "America/New_York"
     settings:


### PR DESCRIPTION
Client is not supported by some trackers yet

Reverts onedr0p/home-ops#2641