### PR TITLE
Revert "fix(container): update image public.ecr.aws/docker/library/redis to v7.0.7"

### DIFF
--- a/kubernetes/apps/default/immich/app/redis/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/redis/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
         reloader.stakater.com/auto: "true"
     image:
       repository: public.ecr.aws/docker/library/redis
-      tag: 7.0.7
+      tag: 7.0.6
     env:
       REDIS_REPLICATION_MODE: master
     envFrom:


### PR DESCRIPTION
Reverts onedr0p/home-ops#4429