### PR TITLE
feat: improved support for custom dependency urls

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,7 +56,10 @@
         // Example: `k3s_release_version: "v1.27.3+k3s1"`
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?\"(?<currentValue>.*)\"\n",
         // Example: `- https://github.com/rancher/system-upgrade-controller/releases/download/v0.11.0/crd.yaml`
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?-\\s(.*?)\/(?<currentValue>[^/]+)\/[^/]+\n",
+        //          `- https://github.com/argoproj/argo-cd/raw/v2.7.10/manifests/install.yaml`
+        //          `- https://github.com/argoproj/argo-cd/raw/v2.7.10/manifests/ha/install.yaml`
+        //          `- https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/21.1.1/kubernetes/kubernetes.yml`
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?-\\s(.*?)\/(?<currentValue>(v|\\d)[^/]+)\/\\S+\n",
         // Example: apiVersion=helm.cattle.io/v1 kind=HelmChart
         "datasource=(?<datasource>\\S+)\n.*?repo: (?<registryUrl>\\S+)\n.*?chart: (?<depName>\\S+)\n.*?version: (?<currentValue>\\S+)\n"
       ],


### PR DESCRIPTION
The updated regex supports a wider range of commonly used URL patterns, e.g.

```
- https://github.com/argoproj/argo-cd/raw/v2.7.10/manifests/install.yaml
- https://github.com/argoproj/argo-cd/raw/v2.7.10/manifests/ha/install.yaml
- https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/21.1.1/kubernetes/kubernetes.yml
```