### PR TITLE
Fix: move undeclared vars to preconditions in Taskfile.yaml for impro…

### DIFF
--- a/.taskfiles/Ansible/Taskfile.yaml
+++ b/.taskfiles/Ansible/Taskfile.yaml
@@ -32,13 +32,12 @@ tasks:
       .venv/bin/ansible-playbook \
         --inventory {{.ANSIBLE_DIR}}/{{.cluster}}/inventory/hosts.yaml \
         {{.ANSIBLE_DIR}}/{{.cluster}}/playbooks/{{.playbook}}.yaml {{.CLI_ARGS}}
-    vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
-      playbook: '{{ or .playbook (fail "Argument (playbook) is required") }}'
     preconditions:
-      - { msg: "Venv not found",      sh: "test -d {{.ROOT_DIR}}/.venv" }
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }
+      - { msg: "Argument (playbook) is required", sh: 'test -n "{{.playbook}}"' }
+      - { msg: "Venv not found", sh: "test -d {{.ROOT_DIR}}/.venv" }
       - { msg: "Inventory not found", sh: "test -f {{.ANSIBLE_DIR}}/{{.cluster}}/inventory/hosts.yaml" }
-      - { msg: "Playbook not found",  sh: "test -f {{.ANSIBLE_DIR}}/{{.cluster}}/playbooks/{{.playbook}}.yaml" }
+      - { msg: "Playbook not found", sh: "test -f {{.ANSIBLE_DIR}}/{{.cluster}}/playbooks/{{.playbook}}.yaml" }
 
   .venv:
     internal: true

--- a/.taskfiles/ExternalSecrets/Taskfile.yaml
+++ b/.taskfiles/ExternalSecrets/Taskfile.yaml
@@ -15,11 +15,12 @@ tasks:
     env:
       KUBECONFIG: "{{.KUBERNETES_DIR}}/{{.cluster}}/kubeconfig"
     vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
       ns: '{{.ns | default "default"}}'
       secret: '{{ or .secret (fail "Argument (secret) is required") }}'
     preconditions:
       - { msg: "ExternalSecret not found", sh: "kubectl --context {{.cluster}} -n {{.ns}} get externalsecret {{.secret}}" }
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }
+
 
   sync-all:
     desc: Sync all ExternalSecrets for a cluster
@@ -36,6 +37,7 @@ tasks:
     env:
       KUBECONFIG: "{{.KUBERNETES_DIR}}/{{.cluster}}/kubeconfig"
     vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
       secrets:
         sh: kubectl --context {{.cluster}} get externalsecret --all-namespaces --no-headers -A | awk '{print $1 "|" $2}'
+    preconditions:
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }

--- a/.taskfiles/Flux/Taskfile.yaml
+++ b/.taskfiles/Flux/Taskfile.yaml
@@ -18,9 +18,9 @@ tasks:
       - kubectl --context {{.cluster}} apply --server-side --kustomize {{.KUBERNETES_DIR}}/{{.cluster}}/flux/vars
       - kubectl --context {{.cluster}} apply --server-side --kustomize {{.KUBERNETES_DIR}}/{{.cluster}}/flux/config
       - defer: sops --encrypt --in-place {{.KUBERNETES_DIR}}/{{.cluster}}/flux/vars/cluster-secrets.sops.env
-    vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
+
     preconditions:
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }
       - { msg: "Age private key not found",      sh: "test -f {{.ROOT_DIR}}/age.key" }
       - { msg: "Age secret not found",           sh: "test -f {{.KUBERNETES_DIR}}/{{.cluster}}/bootstrap/flux/age-key.sops.yaml" }
       - { msg: "Github deploy secret not found", sh: "test -f {{.KUBERNETES_DIR}}/{{.cluster}}/bootstrap/flux/github-deploy-key.sops.yaml" }
@@ -47,10 +47,10 @@ tasks:
       kubectl --context {{.cluster}} apply --server-side \
           --field-manager=kustomize-controller -f -
     vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
       path: '{{ or .path (fail "Argument (path) is required") }}'
       ns: '{{.ns | default "flux-system"}}'
       ks:
         sh: flux --context {{.cluster}} --namespace {{.ns}} get kustomizations $(basename {{.path}}) 2>&1
     preconditions:
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }
       - { msg: "Kustomization file not found", sh: "test -f {{.KUBERNETES_DIR}}/{{.cluster}}/apps/{{.path}}/ks.yaml" }

--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -45,8 +45,8 @@ tasks:
           }
         }'
     vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
       ns: '{{.ns | default "default"}}'
       claim: '{{ or .claim (fail "Argument (claim) is required") }}'
     preconditions:
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }
       - { msg: "PVC not found", sh: "kubectl --context {{.cluster}} -n {{.ns}} get persistentvolumeclaim {{.claim}}" }

--- a/.taskfiles/VolSync/Taskfile.yaml
+++ b/.taskfiles/VolSync/Taskfile.yaml
@@ -39,10 +39,10 @@ tasks:
       - kubectl --context {{.cluster}} -n {{.ns}} delete job list-{{.app}}-{{.ts}}
     env: *env
     vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
       ns: '{{.ns | default "default"}}'
       app: '{{ or .app (fail "Argument (app) is required") }}'
     preconditions:
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }
       - { msg: "Wait script not found",   sh: "test -f {{.scriptsDir}}/wait.sh" }
       - { msg: "List template not found", sh: "test -f {{.templatesDir}}/list.tmpl.yaml" }
     silent: true
@@ -62,10 +62,10 @@ tasks:
       - kubectl --context {{.cluster}} -n {{.ns}} delete job unlock-{{.app}}-{{.ts}}
     env: *env
     vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
       ns: '{{.ns | default "default"}}'
       app: '{{ or .app (fail "Argument (app) is required") }}'
     preconditions:
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }
       - { msg: "Wait script not found",     sh: "test -f {{.scriptsDir}}/wait.sh" }
       - { msg: "Unlock template not found", sh: "test -f {{.templatesDir}}/unlock.tmpl.yaml" }
     silent: true
@@ -95,6 +95,7 @@ tasks:
       controller:
         sh: true && {{.scriptsDir}}/controller.sh {{.app}} {{.ns}} {{.cluster}}
     preconditions:
+      - { msg: "Argument (cluster) is required", sh: 'test -n "{{.cluster}}"' }
       - { msg: "Controller script not found", sh: "test -f {{.scriptsDir}}/controller.sh" }
       - { msg: "Wait script not found",       sh: "test -f {{.scriptsDir}}/wait.sh" }
       - { msg: "RepositorySource not found",  sh: "kubectl --context {{.cluster}} -n {{.ns}} get replicationsources {{.app}}" }
@@ -120,7 +121,6 @@ tasks:
         vars: *env
     env: *env
     vars:
-      cluster: '{{ or .cluster (fail "Argument (cluster) is required") }}'
       ns: '{{.ns | default "default"}}'
       app: '{{ or .app (fail "Argument (app) is required") }}'
       previous: '{{.previous | default 2}}'
@@ -133,6 +133,7 @@ tasks:
       pgid:
         sh: kubectl --context {{.cluster}} -n {{.ns}} get replicationsources/{{.app}} -o jsonpath="{.spec.restic.moverSecurityContext.runAsGroup}"
     preconditions:
+      - { msg: "Argument (cluster) is required",          sh: 'test -n "{{.cluster}}"' }
       - { msg: "Controller script not found",             sh: "test -f {{.scriptsDir}}/controller.sh" }
       - { msg: "Wait script not found",                   sh: "test -f {{.scriptsDir}}/wait.sh" }
       - { msg: "ReplicationDestination script not found", sh: "test -f {{.templatesDir}}/replicationdestination.tmpl.yaml" }


### PR DESCRIPTION
As you know, our infrastructure is very similar, so it's been a little too convenient to leverage your hard work. As solid as your code is, unannounced and/or breaking changes come like Murphy's law!  Your recent feature to support multiple clusters came right during a rebuild 😅 

Although it is a minor contribution, at least it is something. Moving these undeclared vars into preconditions revealed what changed/broke right away.  Hopefully it might help others not to spend countless hours spinning up containers to re-run those task files. 

This pull request is a hotfix for the `.taskfiles` directory, specifically it provides higher reliability and an improved debugging experience with human readable error messages.  Main task changes:

* <a href="diffhunk://#diff-3675f16f2a2426c0202c2337bfb99d15a4ed6f496fbc6e0060d65d4a91ed7f43L18-R23">`.taskfiles/ExternalSecrets/Taskfile.yaml`</a>: Removed the `cluster` variable from the `ExternalSecrets` task and added a precondition to check if the `cluster` argument is required. <a href="diffhunk://#diff-3675f16f2a2426c0202c2337bfb99d15a4ed6f496fbc6e0060d65d4a91ed7f43L18-R23">[1]</a> <a href="diffhunk://#diff-3675f16f2a2426c0202c2337bfb99d15a4ed6f496fbc6e0060d65d4a91ed7f43L39-R43">[2]</a>
* <a href="diffhunk://#diff-a84a56fdfb6af40717bd88a2dece51d6bb2894f75e168444ed59e17a68ec6ebaL65-R68">`.taskfiles/VolSync/Taskfile.yaml`</a>: Removed the `cluster` variable from the `VolSync` task and added preconditions to check if the `cluster` argument is required. <a href="diffhunk://#diff-a84a56fdfb6af40717bd88a2dece51d6bb2894f75e168444ed59e17a68ec6ebaL65-R68">[1]</a> <a href="diffhunk://#diff-a84a56fdfb6af40717bd88a2dece51d6bb2894f75e168444ed59e17a68ec6ebaR136">[2]</a> <a href="diffhunk://#diff-a84a56fdfb6af40717bd88a2dece51d6bb2894f75e168444ed59e17a68ec6ebaR98">[3]</a> <a href="diffhunk://#diff-a84a56fdfb6af40717bd88a2dece51d6bb2894f75e168444ed59e17a68ec6ebaL123">[4]</a> <a href="diffhunk://#diff-a84a56fdfb6af40717bd88a2dece51d6bb2894f75e168444ed59e17a68ec6ebaL42-R45">[5]</a>
* <a href="diffhunk://#diff-fbf64fbd464e037e0a41e401302aad5d2e97349461ef2bf49de7121eaa707631L50-R55">`.taskfiles/Flux/Taskfile.yaml`</a>: Removed the `cluster` variable from the `vars` section of the `Flux` task. <a href="diffhunk://#diff-fbf64fbd464e037e0a41e401302aad5d2e97349461ef2bf49de7121eaa707631L50-R55">[1]</a> <a href="diffhunk://#diff-fbf64fbd464e037e0a41e401302aad5d2e97349461ef2bf49de7121eaa707631L21-R23">[2]</a>
* <a href="diffhunk://#diff-12508a71d29b1e8debbd41484023650c0e2ca98e24d5521b1d2b12550786ba0fL48-R51">`.taskfiles/Kubernetes/Taskfile.yaml`</a>: Removed the `cluster` variable from the `vars` section of the `Kubernetes` task.
* <a href="diffhunk://#diff-4f29f93d86eab54c13f1e781cea247edd7c1269954c84b74c4f0d24f9012936dL35-R37">`.taskfiles/Ansible/Taskfile.yaml`</a>: Added preconditions to the `Ansible` task to check if the `cluster` and `playbook` arguments are required.