### PR TITLE
🐛 bug fix: correct path for .hushlogin of non-root user

### DIFF
--- a/ansible/main/playbooks/cluster-prepare.yaml
+++ b/ansible/main/playbooks/cluster-prepare.yaml
@@ -39,7 +39,7 @@
             key: "https://github.com/{{ github_username }}.keys"
         - name: User Configuration | Silence login
           ansible.builtin.file:
-            dest: "{{ ansible_user if ansible_user != 'root' else '/root' }}/.hushlogin"
+            dest: "{{ '/home/' + ansible_user if ansible_user != 'root' else '/root' }}/.hushlogin"
             state: touch
             owner: "{{ ansible_user }}"
             group: "{{ ansible_user }}"


### PR DESCRIPTION
This PR is a minor bug fix for the path directory when creating .hushlogin file in the `cluster-prepare.yaml` playbook.

I would have included another change for the `cluster-installation.yaml` playbook as ansible currently throws the following error: ```ERROR! Using 'ansible.builtin.include_role' as a handler is not supported. ``` Sadly, I cannot find a solution as I have tried alternate modules, but it seems that a handler can't be used for some reason. Perhaps it's a quick fix for you as I have just opted to put a reboot task for now?

Main changes:

* `ansible/main/playbooks/cluster-prepare.yaml`: Modified the `cluster-prepare.yaml` playbook. (ansible/main/playbooks/cluster-prepare.yaml)