### PR TITLE
fix(github-actions): Simplify Labelling Workflows

### DIFF
--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -10,26 +10,19 @@ on:
   schedule:
     - cron: "0 0 * * *" # Every day at midnight
 
+permissions:
+  issues: write
+
 jobs:
   label-sync:
     name: Label Sync
     runs-on: ubuntu-latest
     steps:
-      - name: Generate Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: "${{ secrets.BOT_APP_ID }}"
-          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
-
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          token: "${{ steps.app-token.outputs.token }}"
 
       - name: Sync Labels
         uses: EndBug/label-sync@v2
         with:
-          token: "${{ steps.app-token.outputs.token }}"
           config-file: .github/labels.yaml
           delete-other-labels: true

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/labels.yml
 
       - name: Sync Labels
         uses: EndBug/label-sync@v2

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          sparse-checkout: .github/labels.yml
+          sparse-checkout: .github/labels.yaml
 
       - name: Sync Labels
         uses: EndBug/label-sync@v2

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -15,15 +15,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Generate Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: "${{ secrets.BOT_APP_ID }}"
-          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
-
       - name: Labeler
         uses: actions/labeler@v5
         with:
-          repo-token: "${{ steps.app-token.outputs.token }}"
           configuration-path: .github/labeler.yaml


### PR DESCRIPTION
Not generating the github bot app token on every run saves a bit of time and it is not actually needed for the workflows to function properly.