### PR TITLE
Update recyclarr.yml with assign_scores_to for sonarr and radarr

### DIFF
--- a/kubernetes/main/apps/default/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/main/apps/default/recyclarr/app/resources/recyclarr.yml
@@ -43,7 +43,7 @@ sonarr:
           - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
           - 06d66ab109d4d2eddb2794d21526d140 # Retags
           - 1b3994c551cbb92a2c781af061f4ab44 # Scene
-        quality_profiles:
+        assign_scores_to:
           - name: WEB-1080p
           - name: ANY
 
@@ -73,5 +73,5 @@ radarr:
           - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
           - f537cf427b64c38c8e36298f657e4828 # Scene
-        quality_profiles:
+        assign_scores_to:
           - name: SQP-1 (1080p)


### PR DESCRIPTION
Updates deprecated keys under `custom_formats`.
Ref: https://recyclarr.dev/wiki/upgrade-guide/v8.0/#assign-scores-to 