### PR TITLE
fixed emqx config file

### DIFF
--- a/kubernetes/main/apps/database/emqx/cluster/cluster.yaml
+++ b/kubernetes/main/apps/database/emqx/cluster/cluster.yaml
@@ -12,7 +12,7 @@ spec:
         backend = "built_in_database"
         mechanism = "password_based"
         password_hash_algorithm {
-            name = "bcrypt",
+            name = "bcrypt"
         }
         user_id_type = "username"
         bootstrap_file = "/opt/init-user.json"


### PR DESCRIPTION
having a comma after 'name = "bcrypt"' breaks the emqx container with the following error on initialize

```
[error]: {parse_error,#{line => 11,reason => "syntax error before: endobj",file => "/opt/emqx/etc/emqx.conf"}}

ERROR: call_hocon_failed: -s emqx_conf_schema -c /opt/emqx/etc/emqx.conf multi_get node.data_dir node.name node.cookie node.db_backend cluster.proto_dist node.dist_net_ticktime
```

Line 11 is the bcrypt line. 

Remove the comma and it fires right up.