### PR TITLE
match on namespaces label -- not just default namespace

### DIFF
--- a/kubernetes/main/apps/kyverno/kyverno/policies/volsync-movers.yaml
+++ b/kubernetes/main/apps/kyverno/kyverno/policies/volsync-movers.yaml
@@ -14,13 +14,17 @@ spec:
   rules:
     - name: set-volsync-movers-custom-config
       match:
-        any:
+        all:
           - resources:
               kinds: ["batch/v1/Job"]
-              namespaces: ["default"]
               selector:
                 matchLabels:
                   app.kubernetes.io/created-by: volsync
+          - resources:
+              kinds: ["batch/v1/Job"]
+              namespaceSelector:
+                matchLabels:
+                  volsync.backube/privileged-movers: "true"
       mutate:
         patchStrategicMerge:
           spec:

--- a/kubernetes/main/apps/kyverno/kyverno/policies/volsync-movers.yaml
+++ b/kubernetes/main/apps/kyverno/kyverno/policies/volsync-movers.yaml
@@ -14,17 +14,14 @@ spec:
   rules:
     - name: set-volsync-movers-custom-config
       match:
-        all:
-          - resources:
-              kinds: ["batch/v1/Job"]
-              selector:
-                matchLabels:
-                  app.kubernetes.io/created-by: volsync
-          - resources:
-              kinds: ["batch/v1/Job"]
-              namespaceSelector:
-                matchLabels:
-                  volsync.backube/privileged-movers: "true"
+        resources:
+          kinds: ["batch/v1/Job"]
+          selector:
+            matchLabels:
+              app.kubernetes.io/created-by: volsync
+          namespaceSelector:
+            matchLabels:
+              volsync.backube/privileged-movers: "true"
       mutate:
         patchStrategicMerge:
           spec:


### PR DESCRIPTION
matches on `volsync.backube/privileged-movers: "true"` label instead of explicitly the default namespace only.