### PR TITLE
fix: remove topo contraints due to global policy

### DIFF
--- a/kubernetes/main/apps/default/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/main/apps/default/smtp-relay/app/helmrelease.yaml
@@ -60,13 +60,6 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
         seccompProfile: { type: RuntimeDefault }
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: *app
     service:
       app:
         controller: smtp-relay

--- a/kubernetes/main/apps/kube-system/coredns/app/helm-values.yaml
+++ b/kubernetes/main/apps/kube-system/coredns/app/helm-values.yaml
@@ -49,10 +49,3 @@ tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
     effect: NoSchedule
-topologySpreadConstraints:
-  - maxSkew: 1
-    topologyKey: kubernetes.io/hostname
-    whenUnsatisfiable: DoNotSchedule
-    labelSelector:
-      matchLabels:
-        app.kubernetes.io/instance: coredns

--- a/kubernetes/main/apps/kube-system/fstrim/app/helmrelease.yaml
+++ b/kubernetes/main/apps/kube-system/fstrim/app/helmrelease.yaml
@@ -50,13 +50,6 @@ spec:
     defaultPodOptions:
       hostNetwork: true
       hostPID: true
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: *app
     persistence:
       procfs:
         type: hostPath

--- a/kubernetes/main/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/main/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -40,14 +40,6 @@ spec:
                 - create
                 - update
                 - delete
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/instance: *app
-              app.kubernetes.io/component: admission-controller
       serviceMonitor:
         enabled: true
     backgroundController:

--- a/kubernetes/main/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/main/apps/network/cloudflared/app/helmrelease.yaml
@@ -78,13 +78,6 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
         seccompProfile: { type: RuntimeDefault }
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: *app
     service:
       app:
         controller: cloudflared

--- a/kubernetes/main/apps/network/nginx/external/helmrelease.yaml
+++ b/kubernetes/main/apps/network/nginx/external/helmrelease.yaml
@@ -80,15 +80,6 @@ spec:
       extraArgs:
         default-ssl-certificate: network/devbu-io-tls
       terminationGracePeriodSeconds: 120
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: ingress-nginx
-              app.kubernetes.io/instance: nginx-external
-              app.kubernetes.io/component: controller
       resources:
         requests:
           cpu: 100m

--- a/kubernetes/main/apps/network/nginx/internal/helmrelease.yaml
+++ b/kubernetes/main/apps/network/nginx/internal/helmrelease.yaml
@@ -74,15 +74,6 @@ spec:
       extraArgs:
         default-ssl-certificate: network/devbu-io-tls
       terminationGracePeriodSeconds: 120
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: ingress-nginx
-              app.kubernetes.io/instance: nginx-internal
-              app.kubernetes.io/component: controller
       resources:
         requests:
           cpu: 100m

--- a/kubernetes/main/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/main/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -146,15 +146,6 @@ spec:
             activeCount: 1
             activeStandby: true
             priorityClassName: system-cluster-critical
-            placement:
-              topologySpreadConstraints:
-                - maxSkew: 1
-                  topologyKey: kubernetes.io/hostname
-                  whenUnsatisfiable: DoNotSchedule
-                  labelSelector:
-                    matchLabels:
-                      app.kubernetes.io/name: ceph-mds
-                      app.kubernetes.io/part-of: *cephFileSystemName
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
Global topo was added in https://github.com/onedr0p/home-ops/commit/d00540a78c4b7d57d597e3ebe570b912deca017e