### PR TITLE
fix(helm) worker.config.core.labelSources

### DIFF
--- a/kubernetes/main/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/main/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -30,6 +30,6 @@ spec:
     worker:
       config:
         core:
-          sources: ["pci", "system", "usb"]
+          labelSources: ["pci", "system", "usb"]
     prometheus:
       enable: true


### PR DESCRIPTION
`core.sources` [is now deprecated](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/reference/worker-configuration-reference#coresources).