### PR TITLE
Revert "feat(container): update ghcr.io/siderolabs/kubelet ( v1.31.4 → v1.32.0 )"

### DIFF
--- a/kubernetes/main/bootstrap/apps/helmfile.yaml
+++ b/kubernetes/main/bootstrap/apps/helmfile.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/helmfile
 
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubeVersion: v1.32.0
+kubeVersion: v1.31.4
 
 helmDefaults:
   force: true

--- a/kubernetes/main/cluster.env
+++ b/kubernetes/main/cluster.env
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-KUBERNETES_VERSION=v1.32.0
+KUBERNETES_VERSION=v1.31.4
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 TALOS_VERSION=v1.9.0-beta.0


### PR DESCRIPTION
unsupported upgrade path 1.31->1.32 (from "1.31.4" to "1.32.0")

Reverts onedr0p/home-ops#8464