### PR TITLE
fix: add sops decryption to `FluxInstance` patches

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator/instance/helm-values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/instance/helm-values.yaml
@@ -21,6 +21,17 @@ instance:
       app.kubernetes.io/name: flux
   kustomize:
     patches:
+      # Add Sops decryption
+      - patch: |
+          - op: add
+            path: /spec/decryption
+            value:
+              provider: sops
+              secretRef:
+                name: sops-age
+        target:
+          group: kustomize.toolkit.fluxcd.io
+          kind: Kustomization
       # Increase the number of workers and limits
       # Ref: https://fluxcd.io/flux/installation/configuration/vertical-scaling/#increase-the-number-of-workers-and-limits
       - patch: |

--- a/kubernetes/apps/flux-system/flux-operator/instance/helm-values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/instance/helm-values.yaml
@@ -21,7 +21,7 @@ instance:
       app.kubernetes.io/name: flux
   kustomize:
     patches:
-      # Add Sops decryption
+      # Add Sops decryption to Kustomizations
       - patch: |
           - op: add
             path: /spec/decryption

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -48,17 +48,16 @@ spec:
         kind: Secret
         optional: true
   patches:
-    - patch: |-
-        apiVersion: kustomize.toolkit.fluxcd.io/v1
-        kind: Kustomization
-        metadata:
-          name: not-used
-        spec:
-          decryption:
+    - patch: |
+        - op: add
+          path: /spec/decryption
+          value:
             provider: sops
             secretRef:
               name: sops-age
-          postBuild:
+        - op: add
+          path: /spec/postBuild
+          value:
             substituteFrom:
               - name: cluster-settings
                 kind: ConfigMap

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -56,14 +56,15 @@ spec:
             secretRef:
               name: sops-age
         - op: add
-          path: /spec/postBuild/substituteFrom
+          path: /spec/postBuild
           value:
-            - name: cluster-settings
-              kind: ConfigMap
-              optional: true
-            - name: cluster-secrets
-              kind: Secret
-              optional: true
+            substituteFrom
+              - name: cluster-settings
+                kind: ConfigMap
+                optional: true
+              - name: cluster-secrets
+                kind: Secret
+                optional: true
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -56,13 +56,13 @@ spec:
             secretRef:
               name: sops-age
         - op: add
-          path: /spec/postBuild/substituteFrom/-
+          path: /spec/postBuild/substituteFrom/-/
           value:
             name: cluster-settings
             kind: ConfigMap
             optional: true
         - op: add
-          path: /spec/postBuild/substituteFrom/-
+          path: /spec/postBuild/substituteFrom/-/
           value:
             name: cluster-secrets
             kind: Secret

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -48,25 +48,24 @@ spec:
         kind: Secret
         optional: true
   patches:
-    - patch: |
-        - op: add
-          path: /spec/decryption
-          value:
+    - patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          decryption:
             provider: sops
             secretRef:
               name: sops-age
-        - op: add
-          path: /spec/postBuild/substituteFrom/-/
-          value:
-            name: cluster-settings
-            kind: ConfigMap
-            optional: true
-        - op: add
-          path: /spec/postBuild/substituteFrom/-/
-          value:
-            name: cluster-secrets
-            kind: Secret
-            optional: true
+          postBuild:
+            substituteFrom:
+              - name: cluster-settings
+                kind: ConfigMap
+                optional: true
+              - name: cluster-secrets
+                kind: Secret
+                optional: true
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -58,7 +58,7 @@ spec:
         - op: add
           path: /spec/postBuild
           value:
-            substituteFrom
+            substituteFrom:
               - name: cluster-settings
                 kind: ConfigMap
                 optional: true

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -56,15 +56,17 @@ spec:
             secretRef:
               name: sops-age
         - op: add
-          path: /spec/postBuild
+          path: /spec/postBuild/substituteFrom/-
           value:
-            substituteFrom:
-              - name: cluster-settings
-                kind: ConfigMap
-                optional: true
-              - name: cluster-secrets
-                kind: Secret
-                optional: true
+            name: cluster-settings
+            kind: ConfigMap
+            optional: true
+        - op: add
+          path: /spec/postBuild/substituteFrom/-
+          value:
+            name: cluster-secrets
+            kind: Secret
+            optional: true
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -56,15 +56,14 @@ spec:
             secretRef:
               name: sops-age
         - op: add
-          path: /spec/postBuild
+          path: /spec/postBuild/substituteFrom
           value:
-            substituteFrom:
-              - name: cluster-settings
-                kind: ConfigMap
-                optional: true
-              - name: cluster-secrets
-                kind: Secret
-                optional: true
+            - name: cluster-settings
+              kind: ConfigMap
+              optional: true
+            - name: cluster-secrets
+              kind: Secret
+              optional: true
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization


### PR DESCRIPTION
This patch only applies to the flux-system KS