### PR TITLE
fix: disable per-rbd scraping

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -78,7 +78,6 @@ spec:
       - name: ceph-blockpool
         spec:
           failureDomain: host
-          enableRBDStats: true
           replicated:
             size: 3
         storageClass:


### PR DESCRIPTION
These aren't dashboarded so no reason to inflate prom memory