### PR TITLE
Revert "chore: move ceph cluster config"

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -40,12 +40,12 @@ spec:
           path: /
     toolbox:
       enabled: true
+    configOverride: |
+      [global]
+      bdev_enable_discard = true
+      bdev_async_discard = true
+      osd_class_update_on_start = false
     cephClusterSpec:
-      cephConfig:
-        global:
-          bdev_enable_discard: "true"
-          bdev_async_discard: "true"
-          osd_class_update_on_start: "false"
       crashCollector:
         disable: false
       csi:


### PR DESCRIPTION
Reverts onedr0p/home-ops#8913

```
  - lastHeartbeatTime: "2025-03-03T13:18:15Z"
    lastTransitionTime: "2025-03-03T13:18:15Z"
    message: 'failed to create cluster: failed to execute post actions after all the
      ceph monitors started: : failed to set ceph config for target: global: failed
      to set keys [bdev_async_discard]'
    reason: ClusterProgressing
    status: "False"
    type: Progressing
  message: 'failed to create cluster: failed to execute post actions after all the
    ceph monitors started: : failed to set ceph config for target: global: failed
    to set keys [bdev_async_discard]'
```