### PR TITLE
feat(container): update image ghcr.io/home-operations/charts-mirror/external-dns ( 1.15.2 → 1.16.0 )

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run flux-local test
-        uses: docker://ghcr.io/allenporter/flux-local:v7.2.1
+        uses: docker://ghcr.io/allenporter/flux-local:v7.3.0
         with:
           args: test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster -v
 

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -65,7 +65,7 @@ jobs:
           path: default
 
       - name: Run flux-local diff
-        uses: docker://ghcr.io/allenporter/flux-local:v7.2.1
+        uses: docker://ghcr.io/allenporter/flux-local:v7.3.0
         with:
           args: >-
             diff ${{ matrix.resources }}

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -45,7 +45,7 @@ jobs:
           ref: "${{ matrix.branches == 'default' && github.event.repository.default_branch || '' }}"
 
       - name: Gather Images
-        uses: docker://ghcr.io/allenporter/flux-local:v7.2.1
+        uses: docker://ghcr.io/allenporter/flux-local:v7.3.0
         with:
           args: >-
             get cluster

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -26,12 +26,12 @@ spec:
     kind: OCIRepository
     name: cloudflare-dns
   install:
-    disableSchemaValidation: true
+    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
-    disableSchemaValidation: true
+    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
     remediation:
       strategy: rollback
       retries: 3

--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.15.2
+    tag: 1.16.0
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns
   verify:
     provider: cosign
@@ -26,18 +26,17 @@ spec:
     kind: OCIRepository
     name: cloudflare-dns
   install:
+    disableSchemaValidation: true
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
+    disableSchemaValidation: true
     remediation:
       strategy: rollback
       retries: 3
   values:
     fullnameOverride: *app
-    image: # TODO: Remove this block when new chart version is released
-      repository: registry.k8s.io/external-dns/external-dns
-      tag: v0.16.1
     provider: cloudflare
     env:
       - name: &name CF_API_TOKEN

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -26,12 +26,12 @@ spec:
     kind: OCIRepository
     name: unifi-dns
   install:
-    disableSchemaValidation: true
+    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
-    disableSchemaValidation: true
+    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
     remediation:
       strategy: rollback
       retries: 3

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.15.2
+    tag: 1.16.0
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns
   verify:
     provider: cosign
@@ -26,18 +26,17 @@ spec:
     kind: OCIRepository
     name: unifi-dns
   install:
+    disableSchemaValidation: true
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
+    disableSchemaValidation: true
     remediation:
       strategy: rollback
       retries: 3
   values:
     fullnameOverride: *app
-    image: # TODO: Remove this block when new chart version is released
-      repository: registry.k8s.io/external-dns/external-dns
-      tag: v0.16.1
     provider:
       name: webhook
       webhook:


### PR DESCRIPTION
Reverts onedr0p/home-ops#9029