### PR TITLE
chore(plex): use yaml anchor

### DIFF
--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -73,7 +73,7 @@ spec:
           lbipam.cilium.io/ips: 192.168.42.128, ::ffff:192.168.42.128
         ports:
           http:
-            port: 32400
+            port: *port
     route:
       app:
         hostnames: ["{{ .Release.Name }}.devbu.io"]


### PR DESCRIPTION
You're already using the anchor for the `route.app.rules.backendrefs.port`