### PR TITLE
Revert "fix(container): update image ghcr.io/perfectra1n/volsync ( v0.15.42 ➔ 0.15.43 )"

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
     fullnameOverride: volsync # Required for volsync-perfectra1n fork
     image: &image
       repository: ghcr.io/perfectra1n/volsync
-      tag: 0.15.43
+      tag: v0.15.42
     kopia: *image
     rclone: *image
     restic: *image


### PR DESCRIPTION
Reverts onedr0p/home-ops#9784