### PR TITLE
feat(rook-ceph): upgrade ceph to tentacle

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -10,10 +10,6 @@ spec:
     name: rook-ceph
   interval: 1h
   values:
-    csi:
-      # No-op on the v1.20 chart; kept so the HR spec is unchanged and helm-controller
-      # only upgrades once the v1.20.5 artifact is fetched, never the cached v1.19.9
-      cephFSKernelMountOptions: ms_mode=prefer-crc
     image:
       repository: ghcr.io/rook/ceph
     monitoring:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -11,12 +11,6 @@ spec:
   interval: 1h
   timeout: 10m
   values:
-    # Keep Ceph on Squid for the chart migration; Tentacle (v20) lands separately.
-    # The chart derives both cephVersion and the toolbox image from cephImage, and
-    # setting cephClusterSpec.cephVersion alongside it renders a duplicate key.
-    cephImage:
-      repository: quay.io/ceph/ceph
-      tag: v19.2.6
     cephClusterSpec:
       cephConfig:
         mon:
@@ -35,6 +29,16 @@ spec:
         urlPrefix: /
         ssl: false
         prometheusEndpoint: http://prometheus-operated.o11y.svc.cluster.local:9090
+      healthCheck:
+        muteHealthWarning:
+          AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_CLIENT_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_KEYS_ALLOWED:
+            policy: mute
+          AUTH_INSECURE_KEYS_CREATABLE:
+            policy: mute
       mgr:
         modules:
           - name: pg_autoscaler
@@ -51,6 +55,8 @@ spec:
           daemon:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
+          csi:
+            keyType: aes # aes256k requires kernel 7.0+
       storage:
         devicePathFilter: /dev/disk/by-id/nvme-Micron_7450_MTFDKBA800TFS_.*
         useAllDevices: false


### PR DESCRIPTION
## Description

Follow-up to #11548: upgrades Ceph from Squid to Tentacle and finishes the cephx/health cleanup, per the [cephx key rotation guide](https://github.com/rook/rook/blob/v1.20.5/Documentation/Storage-Configuration/Advanced/cephx-key-rotation.md).

Changes:

- `cephImage` pin removed; the cluster now follows the chart defaults, currently `quay.io/ceph/ceph:v20.2.4` (Tentacle). Verified by rendering the v1.20.5 chart with these values: the CephCluster and toolbox both resolve to the quay image, and `allowUnsupported` stays false (Tentacle is supported). Ceph image bumps now ride along with rook-ceph-cluster chart bumps.
- `security.cephx.csi.keyType: aes` added. AES256K CSI keys require Linux kernel 7.0+ and the nodes run 6.18, so this pins the CSI key type Rook is allowed to create (the rotation guide says to always set it). No CSI key rotation is initiated (`keyRotationPolicy` unset), so PV connections are untouched. Daemon keys are already generation 2 on `aes256k` from the existing daemon rotation config.
- The imperative sticky `ceph health mute` entries are converted to declarative `healthCheck.muteHealthWarning` for the four `AUTH_INSECURE_*` warnings. With CSI (and rbd-mirror-peer) keys constrained to `aes` by the kernel, these warnings cannot fully clear; the guide says muting them is the expected state. `AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE` is included because it surfaces transiently for 2-3 hours after daemon key migration. Unmute after the nodes reach kernel 7.0+ and CSI keys migrate to `aes256k`.
- The stale `csi.cephFSKernelMountOptions` no-op removed from the operator chart values (it was kept in #11548 only to avoid a double helm upgrade during the v1.20.5 artifact fetch; the v1.20.5 artifact is now the cached one, so removing it triggers a single no-op upgrade).

Expected after merge: all Ceph daemons restart once rolling from v19.2.6 to v20.2.4 (mons, mgr, OSDs, MDS), CSI pods unaffected, no key rotation. Ceph reports `HEALTH_WARN: AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE` for up to 2-3 hours after the upgrade while service tokens rotate, which the new mute covers.
