### PR TITLE
chore(talos): remove HPAScaleToZero feature gate

### DIFF
--- a/talos/controlplane.yaml.j2
+++ b/talos/controlplane.yaml.j2
@@ -35,7 +35,6 @@ certExtraSANs:
   - k8s.internal
 extraArgs:
   enable-aggregator-routing: "true"
-  feature-gates: HPAScaleToZero=true
 image: registry.k8s.io/kube-apiserver:v1.37.0
 ---
 apiVersion: v1alpha1
@@ -71,7 +70,6 @@ apiVersion: v1alpha1
 kind: KubeControllerManagerConfig
 extraArgs:
   bind-address: 0.0.0.0
-  feature-gates: HPAScaleToZero=true
 image: registry.k8s.io/kube-controller-manager:v1.37.0
 ---
 apiVersion: v1alpha1


### PR DESCRIPTION
## Summary

Removes `feature-gates: HPAScaleToZero=true` from the `KubeAPIServerConfig` and `KubeControllerManagerConfig` documents in `talos/controlplane.yaml.j2`.

`HPAScaleToZero` graduated to Beta and is enabled by default in Kubernetes 1.37 (`pkg/features/kube_features.go` at the `v1.37.0` tag), which the cluster moved to in #11598. The explicit gate no longer does anything. The 15 HPAs with `minReplicas: 0` continue to scale to zero.

## Verification

- Rendered the three config layers for `k8s-0` with `talosctl machineconfig patch`; the result contains no `HPAScaleToZero` and the two `extraArgs` blocks are otherwise unchanged (`enable-aggregator-routing` and `bind-address` remain).
- `talosctl validate -m metal` passes apart from the placeholder secret used in place of the 1Password reference.

## Rollout

Nothing applies automatically. After merge, `just talos apply-node <node>` on each control-plane node; Talos restarts kube-apiserver and kube-controller-manager on that node, no reboot or drain. A `--dry-run` first should show only the two dropped args.