### PR TITLE
chore(talos): tune tcp buffers, drop hugepages, raise nfs nconnect

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -138,7 +138,7 @@ params:
   net.ipv4.tcp_slow_start_after_idle: "0"
   net.ipv4.tcp_window_scaling: "1"
   net.ipv4.tcp_wmem: 4096 65536 67108864
-  net/ipv6/conf/bond0.70/disable_ipv6: "1" # keep the host off IPv6 on the IoT segmen
+  net/ipv6/conf/bond0.70/disable_ipv6: "1" # keep the host off IPv6 on the IoT segment
   sunrpc.tcp_max_slot_table_entries: "128"
   sunrpc.tcp_slot_table_entries: "128"
   user.max_user_namespaces: "11255"

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -142,7 +142,6 @@ params:
   sunrpc.tcp_max_slot_table_entries: "128"
   sunrpc.tcp_slot_table_entries: "128"
   user.max_user_namespaces: "11255"
-  vm.nr_hugepages: "1024"
 ---
 apiVersion: v1alpha1
 kind: EtcFileConfig

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -134,10 +134,10 @@ params:
   net.ipv4.tcp_fastopen: "3"
   net.ipv4.tcp_mtu_probing: "1"
   net.ipv4.tcp_notsent_lowat: "131072"
-  net.ipv4.tcp_rmem: 4096 87380 33554432
+  net.ipv4.tcp_rmem: 4096 131072 67108864
   net.ipv4.tcp_slow_start_after_idle: "0"
   net.ipv4.tcp_window_scaling: "1"
-  net.ipv4.tcp_wmem: 4096 65536 33554432
+  net.ipv4.tcp_wmem: 4096 65536 67108864
   net/ipv6/conf/bond0.70/disable_ipv6: "1" # keep the host off IPv6 on the IoT segmen
   sunrpc.tcp_max_slot_table_entries: "128"
   sunrpc.tcp_slot_table_entries: "128"
@@ -152,7 +152,7 @@ contents: |
   [ NFSMount_Global_Options ]
   nfsvers=4.2
   hard=True
-  nconnect=8
+  nconnect=16
   noatime=True
   rsize=1048576
   wsize=1048576


### PR DESCRIPTION
## Changes

- `net.ipv4.tcp_rmem` / `net.ipv4.tcp_wmem` max raised from 32MiB to 64MiB so the TCP autotuning cap matches `net.core.rmem_max` / `net.core.wmem_max`. `tcp_rmem[1]` bumped from 87380 to 131072, the current kernel default. Pod network namespaces inherit these values from the host, so this reaches workloads.
- `vm.nr_hugepages` removed. No workload in the cluster requests `hugepages-*` resources, so the 2GiB reservation per node was idle.
- `nfsmount.conf` `nconnect` raised from 8 to 16.

## Notes

Checked live counters on all three nodes before deciding what to carry over from the reference config: `softnet_stat` drops, `ListenOverflows` and `ListenDrops` are all 0, so `netdev_max_backlog`, `somaxconn` and `tcp_max_syn_backlog` were left alone. The other per-netns candidates (`ip_local_port_range`, `tcp_fin_timeout`, `tcp_tw_reuse`) only affect host-namespace sockets and were skipped.