### PR TITLE
chore(talos): filter host LVM scanning off DRBD, device-mapper and loop devices

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -157,6 +157,20 @@ contents: |
   wsize=1048576
 ---
 apiVersion: v1alpha1
+kind: EtcFileConfig
+name: lvm/lvm.conf
+mode: 0o644
+contents: |
+  backup {
+    backup = 0
+    archive = 0
+  }
+  devices {
+    # Keep Talos LVM autoactivation off DRBD, device-mapper and loop devices
+    global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/loop.*|" ]
+  }
+---
+apiVersion: v1alpha1
 kind: CRICustomizationConfig
 name: containerd
 content: |


### PR DESCRIPTION
## Changes

Adds an `EtcFileConfig` for `/etc/lvm/lvm.conf` that keeps the Talos backup-disable block and adds a `global_filter` rejecting `/dev/drbd*`, `/dev/dm-*` and `/dev/loop*`.

Talos runs `pvscan --cache` and `vgchange -aay` on discovered block devices (`controllers/storage/lvm_activation.go`). The shipped `lvm.conf` only disables backups, so a volume group living inside a DRBD volume or a VM disk on a device-mapper node would be scanned and activated on the host. The miroir PVs sit on the raw NVMe, not on those paths, and miroir-agent uses its own `lvm.conf` (it mounts `/run/lvm` and `/dev`, not `/etc/lvm`), so the miroir thin pools are unaffected.

`EtcFileConfig` accepts nested names (`foo/bar.conf` is a tested-valid case) and `lvm/` is not on the Talos-managed list. Applies without a reboot.