### PR TITLE
revert: filter host LVM scanning off DRBD, device-mapper and loop devices

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -158,20 +158,6 @@ contents: |
   wsize=1048576
 ---
 apiVersion: v1alpha1
-kind: EtcFileConfig
-name: lvm/lvm.conf
-mode: 0o644
-contents: |
-  backup {
-    backup = 0
-    archive = 0
-  }
-  devices {
-    # Keep Talos LVM autoactivation off DRBD, device-mapper and loop devices
-    global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/loop.*|" ]
-  }
----
-apiVersion: v1alpha1
 kind: CRICustomizationConfig
 name: containerd
 content: |


### PR DESCRIPTION
Reverts #11609.

## Why

`talosctl apply-config` rejects the merged config on every node:

```
EtcFileConfig/lvm/lvm.conf: user etc file "lvm/lvm.conf" is managed by Talos
```

`EtcFileConfig` refuses any name under a hard-coded `managedEtcPrefixes` list (`apparmor.d/`, `apparmor/`, `ca-certificates/`, `cni/`, `cri/`, `iscsi/`, `kubernetes/`, `lvm/`, `nvme/`, `pki/`, `selinux/`, `ssl/`) in `pkg/machinery/config/types/runtime/etc_file.go`. `lvm/` has been on that list since the document was introduced in Talos 1.14 (siderolabs/talos@eae11ab0cf) and is still there on `main`.

There is no other supported way to override `/etc/lvm/lvm.conf` on 1.14:

- System extensions may only ship `/etc/cri/conf.d`, `/etc/ld.so.*`, `/usr/lib/{firmware,modules}` and `/usr/local` (`pkg/machinery/extensions` `AllowedPaths`).
- The LVM activation controller has no configuration input, and the upcoming `LVMVolumeGroupConfig` / `LVMLogicalVolumeConfig` documents on `main` carry no filter or activation setting.
- The deprecated legacy `machine.files` block with `op: overwrite` still works (it writes to `/var/etc/lvm/lvm.conf` and bind-mounts it, with no managed-prefix check), but this repo moved off `machine.files` in the multidoc migration and every apply would log a deprecation warning.

## Impact

None on the running cluster. The document was rejected at validation, so nothing was applied to the nodes. The filter is also a no-op on the current cluster: the only LVM PV signature Talos sees on any node is the miroir raw volume (`nvme1n1p1`), and every `drbd*`, `dm-*` and `loop*` device carries ext4, squashfs or no signature.

## Follow-up

Revisit when a VM workload lands on miroir (guest images with LVM inside would get their volume groups activated on the host). At that point either carry the legacy `machine.files` block or push upstream for an `lvm/` exemption or a devices filter on the new LVM documents.