### PR TITLE
chore(talos): disable kernel audit and the Talos auditd service

### DIFF
--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -1,11 +1,13 @@
 ---
 customization:
   extraKernelArgs:
+    - audit=0 # Kernel audit off; SELinux permissive AVC records on unlabeled PV dirs exceed the rate limit
     - i915.enable_guc=3 # Meteor Lake CPU & Intel iGPU
     - intel_iommu=on # PCI Passthrough
     - iommu=pt # PCI Passthrough
     - module_blacklist=igc # Thunderbolt NICs (disable igc)
     - sysctl.kernel.kexec_load_disabled=1 # Meteor Lake CPU & Intel iGPU
+    - talos.auditd.disabled=1 # Talos auditd needs NETLINK_AUDIT, which audit=0 removes
     - thunderbolt.host_reset=0 # Thunderbolt NICs
   systemExtensions:
     officialExtensions:

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -1,13 +1,12 @@
 ---
 customization:
   extraKernelArgs:
-    - audit=0 # Kernel audit off; SELinux permissive AVC records on unlabeled PV dirs exceed the rate limit
     - i915.enable_guc=3 # Meteor Lake CPU & Intel iGPU
     - intel_iommu=on # PCI Passthrough
     - iommu=pt # PCI Passthrough
     - module_blacklist=igc # Thunderbolt NICs (disable igc)
     - sysctl.kernel.kexec_load_disabled=1 # Meteor Lake CPU & Intel iGPU
-    - talos.auditd.disabled=1 # Talos auditd needs NETLINK_AUDIT, which audit=0 removes
+    - talos.auditd.disabled=1
     - thunderbolt.host_reset=0 # Thunderbolt NICs
   systemExtensions:
     officialExtensions:


### PR DESCRIPTION
## Summary

Adds `audit=0` and `talos.auditd.disabled=1` to the shared Image Factory schematic (`talos/schematic.yaml.j2`).

## What is actually happening

Talos runs its own `auditd` service (`internal/app/auditd`), which enables kernel audit, sets `audit_rate_limit=4096` and `audit_backlog_limit=8192`, and writes every record to `talosctl logs auditd`. On these nodes the stream is dominated by SELinux permissive-mode AVC denials, `scontext=pod_containerd_t` on `tcontext=unlabeled_t` `tclass=dir`, and every AVC drags SYSCALL/CWD/PATH/PROCTITLE/EOE records with it:

- k8s-0: mostly `victoria-logs` writing its RBD volume, some ceph-mon; `audit_lost` 222M since the 08-26 boot
- k8s-2: `fn_monstore`, `flux-operator`, containerd, kubelet, qbittorrent; 19M
- k8s-1: containerd, kubelet, cilium-agent, source-controller, sonarr; 2.7M

The rate limit is what produces the `audit: rate limit exceeded` / `audit_lost=` lines in dmesg. This is the same pattern as siderolabs/talos#13744 and #13807 (unlabeled CSI volumes and permissive SELinux); there is no Talos config knob to exclude those records today.

## Why both args

- `talos.auditd.disabled=1` is the documented way to turn off the Talos service (kernel.md reference). Alone it makes dmesg worse: `audit_log_start()` has no `audit_enabled` gate, so AVC records are still generated and kauditd falls back to printk (exactly the flood described in #13744).
- `audit=0` alone sets `audit_initialized = AUDIT_DISABLED`, so no records are generated, but the NETLINK_AUDIT socket is never registered and the Talos auditd goroutine (`restart.Forever`) would fail on `NewAuditClient` and restart indefinitely.

Together: nothing is generated and nothing tries to consume it. The cost is losing `talosctl logs auditd` as an AVC source; that matters only when SELinux moves to enforcing, at which point this can be reverted.

## Verification

- Rendering the schematic on `main` and posting it to the factory returns `301818e8…`, matching the installer image in the live machineconfig, so the render path is correct.
- The new schematic is accepted as `1bedad31…` and its stored customization lists both args.

## Rollout

Kernel args are baked into the factory image, so nothing changes until each node is upgraded:

```sh
just talos upgrade-node k8s-0   # then k8s-1, k8s-2
```

After reboot: `talosctl -n <node> read /proc/cmdline` shows both args, `talosctl -n <node> service auditd` is absent, and `talosctl dmesg` stops emitting `audit_lost` lines.

## Not included

The DRBD `received new current UUID` chatter from kopiur snapshots still cycles the dmesg ring buffer in about three hours; that is a separate `log_buf_len=` change.