### PR TITLE
chore(dns): clear DHCP search domains, roll CoreDNS back to 1.13.1, drop the AAAA template

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -142,6 +142,12 @@
       minimumGroupSize: 2,
     },
     {
+      description: "CoreDNS 1.14.3+ prefetch poisons autopath answers, hold until coredns/coredns#8390 is fixed",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/coredns/charts/coredns"],
+      enabled: false,
+    },
+    {
       description: "1Password CLI is not resolvable on GitHub, bump manually",
       matchManagers: ["mise"],
       matchDepNames: ["1password-cli"],

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -28,10 +28,6 @@ spec:
             use_tcp: true
         port: 53
         plugins:
-          - name: template
-            parameters: ANY AAAA
-            configBlock: |-
-              authority "{{ .Zone }} 60 IN SOA ns.dns.cluster.local. hostmaster.cluster.local. (1 60 60 60 60)"
           - name: errors
           - name: health
             configBlock: |-

--- a/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.47.0
+    tag: 1.46.2
   url: oci://ghcr.io/coredns/charts/coredns

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -52,7 +52,7 @@ mtu: 9000
 apiVersion: v1alpha1
 kind: ResolverConfig
 searchDomains:
-  domains: [] # Clears the DHCP-supplied domain so autopath and pod search lists stop probing it upstream
+  domains: []
 hostDNS:
   enabled: true
   forwardKubeDNSToHost: true # Requires Cilium socketLB features

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -51,6 +51,8 @@ mtu: 9000
 ---
 apiVersion: v1alpha1
 kind: ResolverConfig
+searchDomains:
+  domains: [] # Clears the DHCP-supplied domain so autopath and pod search lists stop probing it upstream
 hostDNS:
   enabled: true
   forwardKubeDNSToHost: true # Requires Cilium socketLB features


### PR DESCRIPTION
## Summary

Three DNS changes, one commit each:

- **Talos**: `ResolverConfig.searchDomains.domains: []`. The gateway's DHCP hands the nodes `search internal`; kubelet copies it into every pod `resolv.conf` and CoreDNS `autopath` reads it from its own `resolv.conf`, so every search walk probes `<name>.internal` upstream before trying the bare name. In a 13 minute host DNS log window on k8s-1, 335 of 685 queries forwarded to the gateway were `*.internal.internal.` or `*.svc.cluster.local.internal.`. An explicit empty list is the documented way to replace the DHCP domains instead of merging them (`SearchDomainsOverridden` in the resolver merge controller).
- **CoreDNS chart 1.47.0 → 1.46.2** (CoreDNS 1.14.6 → 1.13.1) with a Renovate hold. CoreDNS 1.14.3+ (coredns/coredns#7944) refreshes cache entries with a synthetic empty remote address, so `kubernetes.AutoPath` cannot match the source pod during a prefetch, the search expanded key gets the kubernetes plugin's NXDOMAIN, and `getIfNotStale` serves that negative entry ahead of the positive one. Tracked as coredns/coredns#8390; the hold rule points at it.
- **Drop `template ANY AAAA`**. It was masking the bug above (AAAA always NODATA, so clients could never build a v6-only dial list). With 1.13.1 the mask is not needed.

## Verification

- Probe pod in `default` against the live 1.14.6 pods, same second, same name: `dig A qbittorrent.default.svc.cluster.local.default.svc.cluster.local` returned NXDOMAIN; `dig +dnssec` (separate cache key, forced miss) returned `CNAME qbittorrent.default.svc.cluster.local` + `A 10.43.126.151`. Same result for `garage-door.internal.default.svc.cluster.local`. `coredns_autopath_success_total` (0.065/s) equals the cache miss rate (0.063/s), so autopath only ever wins on cold keys; NXDOMAIN is 38% of all responses.
- `flate build hr coredns` renders the Corefile without the template block and the image as `mirror.gcr.io/coredns/coredns:1.13.1`.
- Talos: `talosctl apply-config --dry-run` against all three nodes with the new `ResolverConfig` document accepts the config. Note the dry-run diff and `talosctl patch mc` both re-encode and drop the empty list (`domains` is `omitempty`); `apply-config` persists the original bytes (`configloader.NewFromBytes` yields a read-only container whose `Bytes()` returns them), so the override survives reboots. Do not use `patch mc` or `edit mc` on this document.
- Chart appVersions confirmed from the chart repo: 1.46.2 → 1.13.1, 1.47.0 → 1.14.6.

## Rollout

- CoreDNS rolls via Flux on merge.
- The Talos change needs `just talos apply-node <node>` on each node; `ResolverConfig` applies without a reboot. Existing pods keep their old `resolv.conf` until recreated. Anything resolving a bare hostname without `.internal` will still work through the gateway, which answers bare names (`dig k8s-1 @192.168.42.1` returns 192.168.42.11).