### PR TITLE
feat(radarr,prowlarr): set allowed hosts and trusted networks

### DIFF
--- a/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
               PROWLARR__LOG__DBENABLED: "False"
               PROWLARR__LOG__LEVEL: info
+              PROWLARR__SERVER__ALLOWEDHOSTS: prowlarr.turbo.ac,prowlarr.default.svc.cluster.local
               PROWLARR__SERVER__PORT: &port 80
+              PROWLARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               PROWLARR__UPDATE__BRANCH: develop
               TZ: America/New_York
             envFrom:
@@ -46,6 +48,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5

--- a/kubernetes/apps/default/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
+              RADARR__SERVER__ALLOWEDHOSTS: radarr.turbo.ac,radarr.default.svc.cluster.local
               RADARR__SERVER__PORT: &port 80
+              RADARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               RADARR__UPDATE__BRANCH: develop
               TZ: America/New_York
             envFrom:
@@ -46,6 +48,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
Mirrors the sonarr setup from #11579 on radarr and prowlarr, both of which now support these settings (verified in `ConfigFileProvider.cs` at v6.4.3.10645 and v2.6.3.5592):

- `*__SERVER__ALLOWEDHOSTS`: `<app>.turbo.ac,<app>.default.svc.cluster.local` - covers the envoy-internal route plus every in-cluster consumer (cleanrr, recyclarr, and prowlarr app-sync all use the `*.default.svc.cluster.local` FQDNs)
- `*__SERVER__TRUSTEDNETWORKS`: `10.42.0.0/16` - trusts X-Forwarded-* headers from the pod network so `DisabledForLocalAddresses` auth keeps seeing real client IPs
- Readiness probes gain a `Host: localhost` header; the kubelet probes with the pod IP as Host, which host filtering rejects with 400 (localhost is always implicitly allowed)