### PR TITLE
chore(sonarr,radarr,prowlarr): accept any host and drop probe host header

### DIFF
--- a/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
               PROWLARR__LOG__DBENABLED: "False"
               PROWLARR__LOG__LEVEL: info
-              PROWLARR__SERVER__ALLOWEDHOSTS: prowlarr.turbo.ac,prowlarr.default.svc.cluster.local
+              PROWLARR__SERVER__ALLOWEDHOSTS: "*"
               PROWLARR__SERVER__PORT: &port 80
               PROWLARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               PROWLARR__UPDATE__BRANCH: develop
@@ -48,9 +48,6 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
-                    httpHeaders:
-                      - name: Host
-                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5

--- a/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
@@ -28,7 +28,6 @@ spec:
               PROWLARR__LOG__LEVEL: info
               PROWLARR__SERVER__ALLOWEDHOSTS: "*"
               PROWLARR__SERVER__PORT: &port 80
-              PROWLARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               PROWLARR__UPDATE__BRANCH: develop
               TZ: America/New_York
             envFrom:

--- a/kubernetes/apps/default/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
-              RADARR__SERVER__ALLOWEDHOSTS: radarr.turbo.ac,radarr.default.svc.cluster.local
+              RADARR__SERVER__ALLOWEDHOSTS: "*"
               RADARR__SERVER__PORT: &port 80
               RADARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               RADARR__UPDATE__BRANCH: develop
@@ -48,9 +48,6 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
-                    httpHeaders:
-                      - name: Host
-                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5

--- a/kubernetes/apps/default/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr/app/helmrelease.yaml
@@ -28,7 +28,6 @@ spec:
               RADARR__LOG__LEVEL: info
               RADARR__SERVER__ALLOWEDHOSTS: "*"
               RADARR__SERVER__PORT: &port 80
-              RADARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               RADARR__UPDATE__BRANCH: develop
               TZ: America/New_York
             envFrom:

--- a/kubernetes/apps/default/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sonarr/app/helmrelease.yaml
@@ -28,7 +28,6 @@ spec:
               SONARR__LOG__LEVEL: info
               SONARR__SERVER__ALLOWEDHOSTS: "*"
               SONARR__SERVER__PORT: &port 80
-              SONARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               SONARR__UPDATE__BRANCH: develop
               TZ: America/New_York
             envFrom:

--- a/kubernetes/apps/default/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sonarr/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
-              SONARR__SERVER__ALLOWEDHOSTS: sonarr.turbo.ac,sonarr.default.svc.cluster.local
+              SONARR__SERVER__ALLOWEDHOSTS: "*"
               SONARR__SERVER__PORT: &port 80
               SONARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               SONARR__UPDATE__BRANCH: develop
@@ -48,9 +48,6 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
-                    httpHeaders:
-                      - name: Host
-                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
Sets `*__SERVER__ALLOWEDHOSTS` to `*` on sonarr, radarr and prowlarr, removes the `Host: localhost` readiness-probe header that the explicit allowlist required, and drops `*__SERVER__TRUSTEDNETWORKS`.

Why: host filtering adds nothing in this topology. Pod IPs and ClusterIPs are unreachable from the LAN (BGP only advertises Service LB IPs), and envoy-internal already returns 404 for any Host that doesn't match an HTTPRoute, including a spoofed Host behind a valid SNI. The explicit allowlist only added maintenance (every in-cluster consumer must use the exact FQDN) and the probe workaround.

Why `*` rather than unset: `AllowedHostsCheck` warns whenever the list is empty and `AuthenticationRequired` is not `Enabled`. `AllowedHostsParser.Parse("*")` yields one entry so the check passes, and ASP.NET's `MiddlewareConfigurationManager` treats a bare `*` as a top-level wildcard that disables filtering, so runtime behaviour is identical to unset. Verified against the pinned tags (Sonarr v4.0.19.3009, Radarr v6.4.3.10645, Prowlarr v2.6.3.5592).

Why drop `TRUSTEDNETWORKS`: it only feeds ASP.NET's forwarded-headers `KnownNetworks`. The consumers of the resulting client IP are the `DisabledForLocalAddresses` bypass in `UiAuthorizationHandler` (inert under `AUTH__METHOD: External`, which authenticates every request first) and auth/request log lines. Behind envoy-internal every LAN client is RFC1918 and therefore "local" to `IsLocalAddress` either way, so the setting changes nothing but the IP shown in logs.

Known quirk: the Settings > General page validates `AllowedHosts` with `ValidHosts()` on save, and `*` fails that rule, so saving that page in the UI is rejected. Every field on it is env-managed here.