### PR TITLE
fix(kopiur): shorten epochs and run quick maintenance hourly

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -23,5 +23,16 @@ spec:
       name: kopiur-repository-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
+  maintenance:
+    schedule:
+      quick:
+        cron: 0 * * * *
+        jitter: 10m
+      full:
+        cron: 0 3 * * *
+        jitter: 1h
+  parameters:
+    epoch:
+      minDuration: 1h
   scheduleDefaults:
     timezone: America/New_York


### PR DESCRIPTION
## Summary

The `expanse` ClusterRepository has reported `TooManyIndexBlobs` (4053 live index blobs, threshold 1000) since July. Compaction is working: every epoch up to 50 is compacted to a single blob. The count is structural.

Kopia advances an epoch only during a maintenance run, and only once the epoch is older than `minDuration` (default 24h). A closed epoch is not eligible for compaction until it is two epochs behind the write epoch, and each maintenance run compacts exactly one epoch. With roughly 86 index blobs written per hour, the live set is always the current epoch plus the previous one:

| Epoch | State | Index blobs |
|---|---|---|
| 52 (current) | open | 1496 |
| 51 | closed, awaiting compaction | 2565 |
| 50 and older | compacted | 1 each |

## Changes

- `parameters.epoch.minDuration: 1h`. This is the floor for the default 20m `refreshFrequency` (kopia requires refresh x 3 <= minDuration).
- Quick maintenance hourly with 10m jitter instead of every 6h with 30m jitter, so each run advances and compacts one epoch. With 6h epochs alone the live set would oscillate between ~500 and ~1500 and keep flapping the condition.
- Full schedule restated unchanged (daily 03:00, 1h jitter) because the schedule override requires both entries.

Expected live index set is in the low hundreds. Range checkpoints will happen every 7 epochs (about every 10h). Fewer live index blobs also shrinks the per-mover kopia cache footprint that overflowed the 1Gi cache PVC in August.
