### PR TITLE
chore(sonarr,radarr,prowlarr): require auth and drop allowed hosts wildcard

### DIFF
--- a/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
@@ -23,10 +23,9 @@ spec:
               PROWLARR__APP__INSTANCENAME: Prowlarr
               PROWLARR__APP__THEME: dark
               PROWLARR__AUTH__METHOD: External
-              PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              PROWLARR__AUTH__REQUIRED: Enabled
               PROWLARR__LOG__DBENABLED: "False"
               PROWLARR__LOG__LEVEL: info
-              PROWLARR__SERVER__ALLOWEDHOSTS: "*"
               PROWLARR__SERVER__PORT: &port 80
               PROWLARR__UPDATE__BRANCH: develop
               TZ: America/New_York

--- a/kubernetes/apps/default/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr/app/helmrelease.yaml
@@ -23,10 +23,9 @@ spec:
               RADARR__APP__INSTANCENAME: Radarr
               RADARR__APP__THEME: dark
               RADARR__AUTH__METHOD: External
-              RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              RADARR__AUTH__REQUIRED: Enabled
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
-              RADARR__SERVER__ALLOWEDHOSTS: "*"
               RADARR__SERVER__PORT: &port 80
               RADARR__UPDATE__BRANCH: develop
               TZ: America/New_York

--- a/kubernetes/apps/default/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sonarr/app/helmrelease.yaml
@@ -23,10 +23,9 @@ spec:
               SONARR__APP__INSTANCENAME: Sonarr
               SONARR__APP__THEME: dark
               SONARR__AUTH__METHOD: External
-              SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              SONARR__AUTH__REQUIRED: Enabled
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
-              SONARR__SERVER__ALLOWEDHOSTS: "*"
               SONARR__SERVER__PORT: &port 80
               SONARR__UPDATE__BRANCH: develop
               TZ: America/New_York


### PR DESCRIPTION
Sets `*__AUTH__REQUIRED` to `Enabled` and removes `*__SERVER__ALLOWEDHOSTS` on sonarr, radarr and prowlarr.

Why: Sonarr v4.0.19.3011 ([Sonarr/Sonarr@27aac304](https://github.com/Sonarr/Sonarr/commit/27aac304eebb2dbf550ab40ae0d5c5cee9322562)) makes `AllowedHostsCheck` warn when the list contains `*`, which is what #11632 relied on, so the "Allowed Hosts is not configured" warning is back on the live sonarr. Radarr and Prowlarr have not ported the commit yet; the same change is applied to them ahead of it.

Why `Enabled`: the check passes with an empty list when authentication is required. Under `AUTH__METHOD: External` the scheme is wired to `NoAuthenticationHandler`, so every request is already authenticated and the `DisabledForLocalAddresses` bypass in `UiAuthorizationHandler` never runs (it is also skipped whenever `X-Forwarded-For` is present). Flipping it is a behavioural no-op here.

Why drop `ALLOWEDHOSTS`: an empty list makes `ConfigureHostFilteringOptions` install the same bare `*` wildcard at runtime, and removing it clears the quirk from #11632 where saving Settings > General was rejected because `*` fails `ValidHosts()`.

Verified on throwaway sonarr 4.0.19.3011 pods with the new env:

- UI root answers 200 with no credentials, with and without `X-Forwarded-For`.
- API without a key answers 401, the same as the live pod on the current setting.
- `/ping` answers 200 for the pod IP, the external hostname and an arbitrary Host, so the plain readiness probe is unaffected.
- `/api/v3/health` no longer reports `AllowedHostsCheck`; the startup log shows "Allowed Hosts is not configured, accepting requests for any host".
