### PR TITLE
fix(kopiur): set mover cache budgets to fit the 5Gi cache PVCs

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -37,7 +37,7 @@ spec:
       # defaults are 5000 MiB per budget, larger than the whole PVC, so the
       # sweeper never runs and the cache fills the volume.
       contentCacheSizeMb: 512
-      metadataCacheSizeMb: 1536
+      metadataCacheSizeMb: 2048
   parameters:
     epoch:
       minDuration: 1h

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -31,6 +31,13 @@ spec:
       full:
         cron: 0 3 * * *
         jitter: 1h
+  moverDefaults:
+    cache:
+      # Every cache PVC is 5Gi or larger (KOPIUR_CAPACITY default). Kopia's own
+      # defaults are 5000 MiB per budget, larger than the whole PVC, so the
+      # sweeper never runs and the cache fills the volume.
+      contentCacheSizeMb: 512
+      metadataCacheSizeMb: 1536
   parameters:
     epoch:
       minDuration: 1h


### PR DESCRIPTION
## Summary

Sets global kopia cache budgets on the `expanse` ClusterRepository via `spec.moverDefaults.cache`:

- `metadataCacheSizeMb: 2048`
- `contentCacheSizeMb: 512`

## Why

Neither the component SnapshotPolicy nor the ClusterRepository set a cache budget, so every mover writes kopia's defaults (5000 MiB for content and 5000 MiB for metadata) into the cache PVC's repository config. Each budget alone is larger than the entire 5Gi cache PVC, so kopia's sweeper never runs and the cache grows until the volume is full. That is the same `no space left on device` failure class that broke home-assistant-mcp in August (#11322 era, fixed by removing a 1Gi override).

Measured on `kopiur-cache-sonarr` (read-only mount, 2026-09-07):

| Path | Size |
|---|---|
| PVC | 4.9 GiB, 92% used |
| `cache/metadata` | 2.6 GiB |
| `cache/index-blobs` | 0.8 GiB |
| `logs/content-logs` | 0.95 GiB (capped by kopia at 1 GiB) |
| `cache/contents` | 1 MiB |

Growth is roughly 70 MiB per app per day; sonarr had about 430 MiB left and home-assistant was at 86%.

## Sizing

All cache PVCs are 5Gi or larger: the component default is 5Gi, plex is 50Gi, radarr is 10Gi, and no PVC under 5Gi will ever be created. The budgets are therefore sized for the 5Gi floor: 2048 MiB metadata + 512 MiB content + ~1 GiB logs + ~1 GiB index caches stays around 4.5 GiB worst case. The content cache is essentially unused during backups, so 512 MiB is generous. Larger PVCs simply use less than they could.

## Rollout

The budgets are passed on `repository connect`, which every mover runs, so the next scheduled snapshot per app rewrites the cache config and kopia sweeps the existing cache down to the budget. No PVC changes are needed. Validated with `kubectl apply --dry-run=server`.

