### PR TITLE
fix(kopiur): halve metadata cache budget since index-blobs shares the cap

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -35,9 +35,10 @@ spec:
     cache:
       # Every cache PVC is 5Gi or larger (KOPIUR_CAPACITY default). Kopia's own
       # defaults are 5000 MiB per budget, larger than the whole PVC, so the
-      # sweeper never runs and the cache fills the volume.
+      # sweeper never runs and the cache fills the volume. The metadata budget
+      # applies twice: kopia caps the index-blobs cache at the same size.
       contentCacheSizeMb: 512
-      metadataCacheSizeMb: 2048
+      metadataCacheSizeMb: 1024
   parameters:
     epoch:
       minDuration: 1h


### PR DESCRIPTION
## Summary

Lowers `spec.moverDefaults.cache.metadataCacheSizeMb` on the `expanse` ClusterRepository from 2048 to 1024. Follow-up to #11659.

## Why

The sizing in #11659 assumed the `index-blobs` cache lived inside the metadata budget. It does not: kopia's `indexBlobCacheSweepSettings` (`repo/content/committed_read_manager.go`) gives `index-blobs` its own cap equal to `EffectiveMetadataCacheSizeBytes()`, so the metadata number applies twice on every PVC.

Confirmed on `kopiur-cache-sonarr` after the first run with the 2048 budget: `metadata` was swept from 2539 MB to 2067 MB, while `index-blobs` stayed at 827 MB because it is still under its own 2048 MiB ceiling.

Worst case on a 5Gi PVC with 2048:

| Directory | Cap |
|---|---|
| `cache/metadata` | 2048 MiB |
| `cache/index-blobs` | 2048 MiB |
| `cache/contents` | 512 MiB (observed ~1 MB) |
| `logs` | ~1.1 GiB on the 5Gi apps (kopia caps content logs and CLI logs at 1 GiB each) |
| `cache/indexes` | ~107 MiB |
| total | ~5.3 GiB against 4.9 GiB usable |

`index-blobs` accrues roughly 10 MB per day at the current index blob churn, so the 5Gi PVCs would fill again in three to four months, sooner if the blob count ever spikes again.

## Sizing

With 1024 the worst case is about 3.8 GiB. The metadata hot set measured by last-access time is about 300 MB per day on both plex (192k files) and sonarr (5k files), so 1024 MiB still holds several days of cache hits; the mover only ever re-reads the previous snapshot's tree. All cache PVCs remain 5Gi or larger and none smaller will be created.

## Rollout

Same mechanism as #11659: each mover rewrites the cache config on `repository connect`, and kopia sweeps both caches down on the next run. Validated with `kubectl apply --dry-run=server`.
