### PR TITLE
feat(chorus): replicate kopiur repository to r2 via chorus

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -11,6 +11,7 @@ postinstall = "lefthook install"
 [tools]
 "1password-cli" = "2.35.0"
 actionlint = "1.7.12"
+"github:clyso/chorus[exe=chorctl,matching=chorctl]" = "v0.7.9"
 "github:home-operations/flate" = "v0.6.5"
 "github:mitsuhiko/minijinja" = "2.24.0"
 jq = "1.8.2"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -35,6 +35,13 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924893"
 provenance = "github-attestations"
 
+[[tools."github:clyso/chorus"]]
+version = "0.7.9"
+backend = "github:clyso/chorus"
+
+[tools."github:clyso/chorus".options]
+matching = "chorctl"
+
 [[tools."github:home-operations/flate"]]
 version = "0.6.5"
 backend = "github:home-operations/flate"

--- a/kubernetes/apps/chorus-system/chorus/app/externalsecret.yaml
+++ b/kubernetes/apps/chorus-system/chorus/app/externalsecret.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: chorus
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: chorus-secret
+    template:
+      data:
+        config.yaml: |
+          storage:
+            storages:
+              garage:
+                credentials:
+                  kopiur:
+                    accessKeyID: "{{ .AWS_ACCESS_KEY_ID }}"
+                    secretAccessKey: "{{ .AWS_SECRET_ACCESS_KEY }}"
+              r2:
+                address: "{{ .R2_ENDPOINT_URL }}"
+                credentials:
+                  kopiur:
+                    accessKeyID: "{{ .R2_ACCESS_KEY_ID }}"
+                    secretAccessKey: "{{ .R2_SECRET_ACCESS_KEY }}"
+  data:
+    - secretKey: R2_ENDPOINT_URL
+      remoteRef:
+        key: kopiur-r2
+        property: AWS_ENDPOINT_URL
+    - secretKey: R2_ACCESS_KEY_ID
+      remoteRef:
+        key: kopiur-r2
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: R2_SECRET_ACCESS_KEY
+      remoteRef:
+        key: kopiur-r2
+        property: AWS_SECRET_ACCESS_KEY
+  dataFrom:
+    - extract:
+        key: kopiur

--- a/kubernetes/apps/chorus-system/chorus/app/helmrelease.yaml
+++ b/kubernetes/apps/chorus-system/chorus/app/helmrelease.yaml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: chorus
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: chorus
+  interval: 1h
+  values:
+    existingCredentialsSecret: chorus-secret
+    storage:
+      main: garage
+      storages:
+        garage:
+          type: S3
+          address: expanse.internal:9000
+          provider: Other
+          isSecure: false
+          defaultRegion: us-east-1
+        r2:
+          type: S3
+          provider: Other
+          isSecure: true
+          defaultRegion: auto
+    redis:
+      enabled: false
+    externalRedis:
+      addresses:
+        - chorus-dragonfly.chorus-system.svc.cluster.local:6379
+      existingSecret: chorus-dragonfly-secret
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+    proxy:
+      replicas: 2
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: chorus
+                  app.kubernetes.io/component: proxy
+      podDisruptionBudget:
+        enabled: true
+      config:
+        auth:
+          useStorage: garage
+      resources:
+        requests:
+          cpu: 10m
+        limits:
+          memory: 256Mi
+    worker:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 10m
+        limits:
+          memory: 512Mi
+    ui:
+      enabled: true

--- a/kubernetes/apps/chorus-system/chorus/app/helmrelease.yaml
+++ b/kubernetes/apps/chorus-system/chorus/app/helmrelease.yaml
@@ -55,7 +55,6 @@ spec:
         limits:
           memory: 256Mi
     worker:
-      replicas: 1
       resources:
         requests:
           cpu: 10m

--- a/kubernetes/apps/chorus-system/chorus/app/helmrelease.yaml
+++ b/kubernetes/apps/chorus-system/chorus/app/helmrelease.yaml
@@ -36,7 +36,6 @@ spec:
       serviceMonitor:
         enabled: true
     proxy:
-      replicas: 2
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/apps/chorus-system/chorus/app/httproute.yaml
+++ b/kubernetes/apps/chorus-system/chorus/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: chorus
+spec:
+  hostnames:
+    - chorus.turbo.ac
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: chorus-ui
+          port: 9672

--- a/kubernetes/apps/chorus-system/chorus/app/kustomization.yaml
+++ b/kubernetes/apps/chorus-system/chorus/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/chorus-system/chorus/app/ocirepository.yaml
+++ b/kubernetes/apps/chorus-system/chorus/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: chorus
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.4.0
+  url: oci://harbor.clyso.com/chorus/chorus

--- a/kubernetes/apps/chorus-system/chorus/ks.yaml
+++ b/kubernetes/apps/chorus-system/chorus/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: chorus
+spec:
+  components:
+    - ../../../../components/dragonfly
+  dependsOn:
+    - name: dragonfly-operator
+      namespace: dragonfly-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: chorus
+      namespace: chorus-system
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      name: chorus-dragonfly
+      namespace: chorus-system
+  healthCheckExprs:
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      failed: status.phase != 'ready'
+      current: status.phase == 'ready'
+  interval: 1h
+  path: ./kubernetes/apps/chorus-system/chorus/app
+  postBuild:
+    substitute:
+      APP: chorus
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: chorus-system
+  wait: false

--- a/kubernetes/apps/chorus-system/kustomization.yaml
+++ b/kubernetes/apps/chorus-system/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: chorus-system
+
+components:
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./chorus/ks.yaml

--- a/kubernetes/apps/chorus-system/namespace.yaml
+++ b/kubernetes/apps/chorus-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/dragonfly-system/dragonfly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/dragonfly-system/dragonfly-operator/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dragonfly-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dragonfly-operator
+  interval: 1h
+  values:
+    manager:
+      image:
+        repository: ghcr.io/dragonflydb/operator
+    grafanaDashboard:
+      enabled: true
+      folder: Dragonfly
+      grafanaOperator:
+        enabled: true
+        matchLabels:
+          dashboards: grafana

--- a/kubernetes/apps/dragonfly-system/dragonfly-operator/app/kustomization.yaml
+++ b/kubernetes/apps/dragonfly-system/dragonfly-operator/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/dragonfly-system/dragonfly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/dragonfly-system/dragonfly-operator/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.6.1
+  url: oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator

--- a/kubernetes/apps/dragonfly-system/dragonfly-operator/ks.yaml
+++ b/kubernetes/apps/dragonfly-system/dragonfly-operator/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dragonfly-operator
+spec:
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: dragonfly-operator
+      namespace: dragonfly-system
+  interval: 1h
+  path: ./kubernetes/apps/dragonfly-system/dragonfly-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: dragonfly-system
+  wait: false

--- a/kubernetes/apps/dragonfly-system/kustomization.yaml
+++ b/kubernetes/apps/dragonfly-system/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dragonfly-system
+
+components:
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./dragonfly-operator/ks.yaml

--- a/kubernetes/apps/dragonfly-system/namespace.yaml
+++ b/kubernetes/apps/dragonfly-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -27,6 +27,8 @@ metadata:
   name: kopiur-repository
 spec:
   dependsOn:
+    - name: chorus
+      namespace: chorus-system
     - name: kopiur
   interval: 1h
   path: ./kubernetes/apps/kopiur-system/kopiur/repository

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -14,7 +14,7 @@ spec:
           name: kopiur-repository-secret
           namespace: kopiur-system
       bucket: kopiur
-      endpoint: expanse.internal:9000
+      endpoint: chorus-proxy.chorus-system.svc.cluster.local:9669
       region: us-east-1
       tls:
         disableTls: true

--- a/kubernetes/components/dragonfly/cluster.yaml
+++ b/kubernetes/components/dragonfly/cluster.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: ${APP}-dragonfly
+spec:
+  replicas: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: ${APP}-dragonfly
+  authentication:
+    passwordFromSecret:
+      name: ${APP}-dragonfly-secret
+      key: password
+  snapshot:
+    cron: "*/5 * * * *"
+    persistentVolumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+      storageClassName: miroir-slow
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+  args:
+    - --dbfilename=dump
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+  resources:
+    requests:
+      cpu: 25m
+    limits:
+      memory: 512Mi

--- a/kubernetes/components/dragonfly/externalsecret.yaml
+++ b/kubernetes/components/dragonfly/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/generators.external-secrets.io/password_v1alpha1.json
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: ${APP}-dragonfly
+spec:
+  length: 32
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-dragonfly
+spec:
+  refreshPolicy: CreatedOnce
+  target:
+    name: ${APP}-dragonfly-secret
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: ${APP}-dragonfly

--- a/kubernetes/components/dragonfly/kustomization.yaml
+++ b/kubernetes/components/dragonfly/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/component.json
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cluster.yaml
+  - ./externalsecret.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/components/dragonfly/podmonitor.yaml
+++ b/kubernetes/components/dragonfly/podmonitor.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${APP}-dragonfly
+spec:
+  selector:
+    matchLabels:
+      app: ${APP}-dragonfly
+  podTargetLabels:
+    - app
+  podMetricsEndpoints:
+    - port: admin
+  fallbackScrapeProtocol: PrometheusText0.0.4


### PR DESCRIPTION
Puts the kopia repository behind a [chorus](https://github.com/clyso/chorus) S3 proxy so writes land on Garage and are mirrored to Cloudflare R2.

## What

- `kubernetes/components/dragonfly`: reusable Dragonfly component. 2 replicas spread across nodes, auth password minted by an External Secrets `Password` generator (`refreshPolicy: CreatedOnce`) into `${APP}-dragonfly-secret`, snapshot PVC on `miroir-slow`, PodMonitor. Image left to the operator default.
- `dragonfly-system`: dragonfly-operator chart `v1.6.1` (ghcr operator image, Grafana dashboard via grafana-operator).
- `chorus-system`: chorus chart `0.4.0` (appVersion v0.7.9). Garage is `main` at `expanse.internal:9000`, R2 is the follower. Proxy runs 2 replicas with hostname anti-affinity and a PDB; worker and UI run 1. Bundled Redis disabled in favour of the Dragonfly component. Metrics and ServiceMonitors enabled. UI exposed at `chorus.turbo.ac` via `envoy-internal`.
- Credentials: Garage keys from the `kopiur` 1Password item, R2 endpoint and keys from `kopiur-r2`, rendered into chorus's `override.yaml` so the R2 account endpoint stays out of git.
- kopiur: `ClusterRepository` endpoint moved to `chorus-proxy.chorus-system.svc.cluster.local:9669`; `kopiur-repository` now depends on `chorus`. Proxy auth reuses the Garage credentials so kopiur's secret is unchanged.
- `.mise`: `chorctl` via the `github:` backend.

## Post-merge

Replication policy is runtime state, created once:

```sh
export CHORUS_ADDRESS=https://chorus.turbo.ac/api
chorctl repl add -u kopiur -f garage -t r2 -b kopiur
```

This seeds the existing Garage bucket into the `kopiur` R2 bucket and enables live replication of writes through the proxy. R2 is only a usable repository once the seed completes.

## Notes

- Backups and restores now depend on chorus and Dragonfly being up.
- The chorus management API has no authentication of its own; it is reachable only via the internal gateway.
- Validated with `kustomize build` on every new directory, `helm template` against both charts, and kubeconform against the home-operations schemas.