### PR TITLE
fix(chorus): match dragonfly ready phase in health check

### DIFF
--- a/kubernetes/apps/chorus-system/chorus/ks.yaml
+++ b/kubernetes/apps/chorus-system/chorus/ks.yaml
@@ -22,8 +22,7 @@ spec:
   healthCheckExprs:
     - apiVersion: dragonflydb.io/v1alpha1
       kind: Dragonfly
-      failed: status.phase != 'ready'
-      current: status.phase == 'ready'
+      current: has(status.phase) && status.phase == 'Ready'
   interval: 1h
   path: ./kubernetes/apps/chorus-system/chorus/app
   postBuild:


### PR DESCRIPTION
The Dragonfly operator reports `status.phase` as `Ready` (capitalized); the health check compared against `ready`, so Flux flagged the CR as stalled even once it was healthy and `kopiur-repository` never proceeded past its dependency.

Drops the `failed` expression too: the operator has no failure phase, and `ResourcesCreated`, `Configuring`, and `RollingUpdate` are all transitional, so any `failed` clause would false-alarm during normal rollouts.