### PR TITLE
fix(dragonfly): allow undeclared keys in lua scripts

### DIFF
--- a/kubernetes/components/dragonfly/cluster.yaml
+++ b/kubernetes/components/dragonfly/cluster.yaml
@@ -36,6 +36,7 @@ spec:
     - --dbfilename=dump
     - --maxmemory=$(MAX_MEMORY)Mi
     - --proactor_threads=2
+    - --default_lua_flags=allow-undeclared-keys
   resources:
     requests:
       cpu: 25m


### PR DESCRIPTION
Chorus's work queue (asynq) runs Lua scripts that access keys not declared in `KEYS[]`. Dragonfly rejects that by default, so every worker dequeue failed with `script tried accessing undeclared key` and the replication policy never left 0/0.

Sets `--default_lua_flags=allow-undeclared-keys`, Dragonfly's documented remedy for Redis-compatible scripts. Triggers a rolling update of the Dragonfly pods.