### PR TITLE
fix(chorus): disable acl and tagging sync

### DIFF
--- a/kubernetes/apps/chorus-system/chorus/app/helmrelease.yaml
+++ b/kubernetes/apps/chorus-system/chorus/app/helmrelease.yaml
@@ -25,6 +25,9 @@ spec:
           provider: Other
           isSecure: true
           defaultRegion: auto
+    features:
+      tagging: false
+      acl: false
     redis:
       enabled: false
     externalRedis:


### PR DESCRIPTION
The bucket migration step syncs bucket ACLs and tags before listing objects. Garage returns an ACL with no `Owner`, which chorus dereferences unchecked (`service/worker/copy/copy.go:465`), so the `bucket:create` task panics and sits in retry backoff. Garage also reports `GetBucketTagging` as unimplemented.

Kopia uses neither ACLs nor tags, so both feature flags are turned off; the worker skips those syncs and proceeds to the object listing.