### PR TITLE
feat(kopiur): replicate expanse repository to r2

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/externalsecret.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-r2
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kopiur-r2-secret
+    template:
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: kopiur-r2

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -4,3 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./clusterrepository.yaml
+  - ./externalsecret.yaml
+  - ./repositoryreplication.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/repositoryreplication.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/repositoryreplication_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: RepositoryReplication
+metadata:
+  name: expanse-r2
+spec:
+  sourceRef:
+    kind: ClusterRepository
+    name: expanse
+  destination:
+    s3:
+      auth:
+        secretRef:
+          name: kopiur-r2-secret
+      bucket: kopiur
+      endpoint: 0a10060d9ff3ad5770343527ec45f104.r2.cloudflarestorage.com
+      region: auto
+  schedule:
+    cron: 0 5 * * *
+    jitter: 30m
+  sync:
+    parallel: 8


### PR DESCRIPTION
Adds a `RepositoryReplication` that mirrors the `expanse` ClusterRepository to the `kopiur` bucket on Cloudflare R2 with `kopia repository sync-to`, plus an ExternalSecret carrying the R2 keys from the `kopiur-r2` 1Password item.

- Nightly at 05:00 (source timezone, America/New_York) with 30m jitter, after the hourly snapshots and the 03:00 full maintenance.
- `sync.parallel: 8`; the initial seed is ~27k blobs and kopia's default is a single sequential copier.
- Additive sync (`deleteExtra` left false), so blobs pruned by maintenance remain on R2 until that is enabled.
- The destination inherits the source repository's format and password; only R2 access keys are configured. The bucket already holds a partial byte-identical seed from the chorus attempt, which `sync-to` reconciles rather than duplicates.

Post-merge: trigger the first run rather than waiting for 05:00, e.g. `kubectl kopiur replication run expanse-r2 -n kopiur-system`, and watch `kubectl get kopiarepl -n kopiur-system`.