### PR TITLE
chore(talos): drop sysctls at or below kernel defaults

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -139,11 +139,8 @@ params:
   net.ipv4.tcp_notsent_lowat: "131072"
   net.ipv4.tcp_rmem: 4096 131072 67108864
   net.ipv4.tcp_slow_start_after_idle: "0"
-  net.ipv4.tcp_window_scaling: "1"
   net.ipv4.tcp_wmem: 4096 65536 67108864
   net/ipv6/conf/bond0.70/disable_ipv6: "1" # keep the host off IPv6 on the IoT segment
-  sunrpc.tcp_max_slot_table_entries: "128"
-  sunrpc.tcp_slot_table_entries: "128"
   user.max_user_namespaces: "11255"
 ---
 apiVersion: v1alpha1


### PR DESCRIPTION
Removes three entries from `SysctlConfig` that either match the 6.18 kernel default or cap a limit below it. Verified against the v6.18 source and the live values on the nodes (6.18.48-talos).

| sysctl | ours | kernel default | note |
|---|---|---|---|
| `net.ipv4.tcp_window_scaling` | 1 | 1 | compile-time constant, no-op |
| `sunrpc.tcp_max_slot_table_entries` | 128 | 65536 | table grows dynamically since 3.x; this capped in-flight NFS RPCs per transport |
| `sunrpc.tcp_slot_table_entries` | 128 | 2 | only preallocates slots the table would grow into anyway |

`user.max_user_namespaces` is also below the kernel default (11255 vs threads-max / 2, which is 383268 here), but it stays because the [gVisor extension](https://github.com/siderolabs/extensions/tree/main/container-runtime/gvisor) documents it as a requirement. `fs.inotify.max_user_watches` stays because the kernel default on these nodes is 775237, below the configured value.

Applied to all nodes without a reboot; Talos resets the removed keys to kernel defaults on apply.