### PR TITLE
chore(coredns): bump chart to 1.47.1 and pin image to 1.14.7

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -142,12 +142,6 @@
       minimumGroupSize: 2,
     },
     {
-      description: "CoreDNS 1.14.3+ prefetch poisons autopath answers, hold until coredns/coredns#8390 is fixed",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["ghcr.io/coredns/charts/coredns"],
-      enabled: false,
-    },
-    {
       description: "1Password CLI is not resolvable on GitHub, bump manually",
       matchManagers: ["mise"],
       matchDepNames: ["1password-cli"],

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -13,6 +13,7 @@ spec:
     fullnameOverride: coredns
     image:
       repository: mirror.gcr.io/coredns/coredns
+      tag: 1.14.7@sha256:7efd3c635b03efd68c4e8398fc45f0d993d0e9ab016f72c1cefb0fd6d01aa286
     replicaCount: 2
     k8sAppLabelOverride: kube-dns
     priorityClassName: system-cluster-critical

--- a/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.46.2
+    tag: 1.47.1
   url: oci://ghcr.io/coredns/charts/coredns


### PR DESCRIPTION
## Summary

- Bump the CoreDNS OCI chart from 1.46.2 to 1.47.1 (latest).
- Pin the image to `mirror.gcr.io/coredns/coredns:1.14.7` by tag and digest. Chart 1.47.1's appVersion is still 1.14.6, which carries the autopath + prefetch regression tracked in coredns/coredns#8390; that issue was closed today and 1.14.7 is reported to fix it.
- Remove the Renovate rule that disabled updates for the CoreDNS chart; Renovate will now track both the chart and the pinned image tag.

## Verification

- `helm template` of chart 1.47.1 with the HelmRelease values renders the container image as `mirror.gcr.io/coredns/coredns:1.14.7@sha256:7efd3c63...`.
- `.renovaterc.json5` still parses.