### PR TITLE
chore(external-dns): add GA-prefix annotations alongside alpha ones

### DIFF
--- a/kubernetes/apps/default/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/default/smtp-relay/app/helmrelease.yaml
@@ -63,6 +63,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: smtp-relay.turbo.ac
+          external-dns.kubernetes.io/hostname: smtp-relay.turbo.ac
           lbipam.cilium.io/ips: 192.168.69.122
         externalTrafficPolicy: Local
         ports:

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -67,6 +67,7 @@ metadata:
   name: kube-api
   annotations:
     external-dns.alpha.kubernetes.io/hostname: k8s.turbo.ac
+    external-dns.kubernetes.io/hostname: k8s.turbo.ac
     lbipam.cilium.io/ips: 192.168.69.120
 spec:
   type: LoadBalancer

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -51,6 +51,7 @@ metadata:
   name: envoy-external
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname external.turbo.ac
+    external-dns.kubernetes.io/target: *hostname
     gatus.home-operations.com/endpoint: |-
       client:
         dns-resolver: tcp://1.1.1.1:53
@@ -60,6 +61,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
+      external-dns.kubernetes.io/hostname: *hostname
       lbipam.cilium.io/ips: 192.168.69.126
   listeners:
     - name: http
@@ -86,6 +88,7 @@ metadata:
   name: envoy-internal
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname internal.turbo.ac
+    external-dns.kubernetes.io/target: *hostname
     gatus.home-operations.com/endpoint: |-
       group: internal
       guarded: true
@@ -97,6 +100,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
+      external-dns.kubernetes.io/hostname: *hostname
       lbipam.cilium.io/ips: 192.168.69.121
   listeners:
     - name: http
@@ -172,6 +176,7 @@ metadata:
   name: https-redirect
   annotations:
     external-dns.alpha.kubernetes.io/controller: none
+    external-dns.kubernetes.io/controller: none
 spec:
   parentRefs:
     - name: envoy-external


### PR DESCRIPTION
external-dns v0.22.0 (chart 1.22.0, #11687) changed the default annotation prefix to `external-dns.kubernetes.io/` with no fallback. Both instances currently pin `annotationPrefix: external-dns.alpha.kubernetes.io/` so the existing annotations keep working.

This is step one of a three step migration to the GA prefix with no delete window. Only one prefix is honored at a time, and the annotated apps and the two controllers reconcile under separate Flux Kustomizations, so renaming and dropping the pin in one PR would leave whichever side applies first without matching annotations while `policy: sync` is active.

1. This PR: add the `external-dns.kubernetes.io/` annotations alongside the alpha ones with identical values. Nothing reads them yet, so no behavior change.
2. Drop `annotationPrefix` from the cloudflare-dns and unifi-dns HelmReleases. Pods switch to reading the GA keys, which produce the same endpoints.
3. Remove the alpha annotations.

Touched: the envoy-external and envoy-internal Gateways (target and hostname), the https-redirect HTTPRoute (controller: none), the kube-api Service, and the smtp-relay Service.
