### PR TITLE
chore(external-dns): drop annotation prefix pin and use the GA default

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -33,7 +33,6 @@ spec:
       - --zone-id-filter=$(CF_ZONE_ID)
     triggerLoopOnEvent: true
     policy: sync
-    annotationPrefix: external-dns.alpha.kubernetes.io/
     sources:
       - crd
       - gateway-httproute

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -39,7 +39,6 @@ spec:
           timeoutSeconds: 5
     triggerLoopOnEvent: true
     policy: sync
-    annotationPrefix: external-dns.alpha.kubernetes.io/
     sources:
       - gateway-httproute
       - service


### PR DESCRIPTION
Step two of the GA annotation prefix migration (step one: #11688).

Removes `annotationPrefix: external-dns.alpha.kubernetes.io/` from the cloudflare-dns and unifi-dns HelmReleases so both instances read the external-dns v0.22.0 default prefix `external-dns.kubernetes.io/`.

Every annotated resource already carries both prefixes with identical values (verified live on the cluster), so the restarted pods compute the same endpoints and no records change.

Step three removes the alpha annotations once this is deployed.
