### PR TITLE
chore(external-dns): remove alpha-prefix annotations

### DIFF
--- a/kubernetes/apps/default/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/default/smtp-relay/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
       app:
         type: LoadBalancer
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: smtp-relay.turbo.ac
           external-dns.kubernetes.io/hostname: smtp-relay.turbo.ac
           lbipam.cilium.io/ips: 192.168.69.122
         externalTrafficPolicy: Local

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -66,7 +66,6 @@ kind: Service
 metadata:
   name: kube-api
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: k8s.turbo.ac
     external-dns.kubernetes.io/hostname: k8s.turbo.ac
     lbipam.cilium.io/ips: 192.168.69.120
 spec:

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -50,8 +50,7 @@ kind: Gateway
 metadata:
   name: envoy-external
   annotations:
-    external-dns.alpha.kubernetes.io/target: &hostname external.turbo.ac
-    external-dns.kubernetes.io/target: *hostname
+    external-dns.kubernetes.io/target: &hostname external.turbo.ac
     gatus.home-operations.com/endpoint: |-
       client:
         dns-resolver: tcp://1.1.1.1:53
@@ -60,7 +59,6 @@ spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: *hostname
       external-dns.kubernetes.io/hostname: *hostname
       lbipam.cilium.io/ips: 192.168.69.126
   listeners:
@@ -87,8 +85,7 @@ kind: Gateway
 metadata:
   name: envoy-internal
   annotations:
-    external-dns.alpha.kubernetes.io/target: &hostname internal.turbo.ac
-    external-dns.kubernetes.io/target: *hostname
+    external-dns.kubernetes.io/target: &hostname internal.turbo.ac
     gatus.home-operations.com/endpoint: |-
       group: internal
       guarded: true
@@ -99,7 +96,6 @@ spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: *hostname
       external-dns.kubernetes.io/hostname: *hostname
       lbipam.cilium.io/ips: 192.168.69.121
   listeners:
@@ -175,7 +171,6 @@ kind: HTTPRoute
 metadata:
   name: https-redirect
   annotations:
-    external-dns.alpha.kubernetes.io/controller: none
     external-dns.kubernetes.io/controller: none
 spec:
   parentRefs:


### PR DESCRIPTION
Step three of the GA annotation prefix migration (steps one and two: #11688, #11689).

Removes the seven `external-dns.alpha.kubernetes.io/` annotations now that both external-dns instances run on the v0.22.0 default prefix and read the `external-dns.kubernetes.io/` keys added in #11688. The two `&hostname` anchors in the envoy Gateways move onto the GA `target` lines.

Nothing reads the alpha keys any more, so no records change. No references to the alpha prefix remain in the repo.
